### PR TITLE
fix: toolchain not available error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vue-dot-com/value_investing_screener
 
-go 1.23
+go 1.23.0
 
 require (
 	github.com/PuerkitoBio/goquery v1.10.0


### PR DESCRIPTION
When building program had error 
go: downloading go1.23 (linux/amd64)
go: download go1.23 for linux/amd64: toolchain not available This is due to go 1.23 set in go mod. Needed 1.23.0